### PR TITLE
CrystalDiskMark move to internal

### DIFF
--- a/automatic/crystaldiskmark/crystaldiskmark.nuspec
+++ b/automatic/crystaldiskmark/crystaldiskmark.nuspec
@@ -81,6 +81,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <files>
         <!-- this section controls what actually gets packaged into the Chocolatey package -->
         <file src="tools\**" target="tools" />
+        <file src="legal\**" target="legal" />
         <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
     </files>
 </package>

--- a/automatic/crystaldiskmark/legal/LICENSE.txt
+++ b/automatic/crystaldiskmark/legal/LICENSE.txt
@@ -1,0 +1,24 @@
+From: <https://crystalmark.info/en/software/crystaldiskmark/crystaldiskmark-license/>
+
+LICENSE
+
+The MIT License (MIT)
+© 2007-2020 hiyohiyo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/automatic/crystaldiskmark/legal/VERIFICATION.txt
+++ b/automatic/crystaldiskmark/legal/VERIFICATION.txt
@@ -1,0 +1,15 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+The installer have been downloaded from their official download link listed on <https://osdn.net/projects/crystaldiskmark/releases/>
+and can be verified like this:
+
+1. Download the following installers:
+  32-Bit: <https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskmark/71859/CrystalDiskMark7_0_0h.exe>
+2. You can use one of the following methods to obtain the checksum
+  - Use powershell function 'Get-Filehash'
+  - Use chocolatey utility 'checksum.exe'
+
+  checksum type: sha256
+  checksum32: 6B908D70EE1AC865A96F8FBEE3C7B9F960D357CD5C02A43DAC082F498C99514B

--- a/automatic/crystaldiskmark/legal/VERIFICATION.txt
+++ b/automatic/crystaldiskmark/legal/VERIFICATION.txt
@@ -1,8 +1,8 @@
 VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
-in verifying that this package's contents are trustworthy.
+in verifying that the contents of this package is trustworthy.
 
-The installer have been downloaded from their official download link listed on <https://osdn.net/projects/crystaldiskmark/releases/>
+The installer has been downloaded from the official download link listed on <https://osdn.net/projects/crystaldiskmark/releases/>
 and can be verified like this:
 
 1. Download the following installers:

--- a/automatic/crystaldiskmark/tools/chocolateyInstall.ps1
+++ b/automatic/crystaldiskmark/tools/chocolateyInstall.ps1
@@ -3,13 +3,12 @@ $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
-    unzipLocation  = $toolsDir
-    url            = 'https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskmark/71859/CrystalDiskMark7_0_0h.exe'
-    checksum       = '6b908d70ee1ac865a96f8fbee3c7b9f960d357cd5c02a43dac082f498c99514b'
-    checksumType   = 'SHA256'
+    file           = Get-Item "$toolsDir\*.exe"
     fileType       = 'EXE'
     silentArgs     = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     validExitCodes= @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs
+Install-ChocolateyInstallPackage @packageArgs
+
+Get-ChildItem $toolsDir\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" } }

--- a/automatic/crystaldiskmark/update.ps1
+++ b/automatic/crystaldiskmark/update.ps1
@@ -6,17 +6,17 @@ $releases    = 'https://osdn.net/projects/crystaldiskmark/releases/'
 
 function global:au_SearchReplace {
     @{
-        ".\tools\chocolateyInstall.ps1" = @{
-            '(^\s*url\s*=\s*)(''.*'')'              = "`$1'$($Latest.URL)'"
-            "(?i)(^\s*checksum\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum)'"
-            "(?i)(^\s*checksumType\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType)'"
+        ".\legal\VERIFICATION.txt" = @{
+            "(?i)(listed on\s*)\<.*\>" = "`${1}<$releases>"
+            "(?i)(32-Bit.+)\<.*\>"     = "`${1}<$($Latest.URL32)>"
+            "(?i)(checksum type:).*"   = "`${1} $($Latest.ChecksumType32)"
+            "(?i)(checksum32:).*"      = "`${1} $($Latest.Checksum32)"
         }
     }
 }
 
 function global:au_BeforeUpdate {
-    $Latest.Checksum = Get-RemoteChecksum $Latest.Url
-    $Latest.ChecksumType = 'SHA256'
+    Get-RemoteFiles -Purge
 }
 
 function global:au_AfterUpdate {
@@ -36,8 +36,9 @@ function global:au_GetLatest {
     $revision   = $matches.revision
 
     return @{
-        URL        = "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskmark/$revision/CrystalDiskMark$versionDL.exe"
+        URL32        = "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskmark/$revision/CrystalDiskMark$versionDL.exe"
         Version    = $versionChoco
+        FileType   = 'exe'
     }
 }
 


### PR DESCRIPTION
* **Does this PR meet the requirements:**
- [x] The commit messages are appropriate
- [x] This has been tested as far as practicable to ensure intended functionality is fine


* **What kind of change does this PR introduce?** (Bug/issue fix, new package, documentation update, etc...)

Fixes #6 

Moves CrystalDiskMark to be an internal package.

* **What does this PR accomplish?** (Links to issues are acceptable)

#6 

* **Does this PR introduce a breaking change or require work elsewhere?**

Nope, should be a smooth upgrade from previous versions.

* **Other context/information**:

I put the required `LICENSE.txt` and `VERIFICATION.txt` in a separate `legal` folder instead of in `tools`. It could be moved back, but a separate legal folder is what the core team repository uses AFAIK. The `VERIFICATION.txt` could be formatted differently, this formatting is just copied so I know `au_SearchReplace` will work reliably. 

There are a couple of ways to get the `file` variable. You could use `Join-Path`, and have AU replace the file name, or you could use `Get-Childitem -Path $toolsDir -Filter '*.exe'`, or something similar.

I moved `$Latest.URL` to `$Latest.URL32` so `Get-RemoteFiles` works properly.
