### PR TITLE
Update/fix Pidgin 2.14.8 checksum

### DIFF
--- a/automatic/pidgin/tools/chocolateyInstall.ps1
+++ b/automatic/pidgin/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@
 $packageArgs = @{
     packageName   = $env:ChocolateyPackageName
     url           = 'https://netcologne.dl.sourceforge.net/project/pidgin/Pidgin/2.14.8/pidgin-2.14.8-offline.exe'
-    checksum 		  = '8245f212a216ab49d52808079f8f882d787681a026d29b33f63f036d676bff67'
+    checksum 		  = 'b237de10d4fe5d44eabe97a7640d2a74b4d722a7cb2376cf5df2be632eda3f51'
     checksumType 	= 'SHA256'
     fileType      = 'EXE'
     silentArgs    = '/S'


### PR DESCRIPTION
Pidgin v2.14.8 failed Chocolatey automated checks due to a bad checksum. Correct checksum can be found at https://sourceforge.net/projects/pidgin/files/Pidgin/2.14.8/pidgin-2.14.8-offline.exe.sha256sum

* **Does this PR meet the requirements:**
- [x] The commit messages are appropriate
- [x] This has been tested as far as practicable to ensure intended functionality is fine


* **What kind of change does this PR introduce?** (Bug/issue fix, new package, documentation update, etc...)
Updates the SHA-256 checksum to correct value


* **What does this PR accomplish?** (Links to issues are acceptable)
Fixes the problem as seen at https://gist.github.com/choco-bot/faff0cf608b0fd8ab1ccd3f1a7dd6cec


* **Does this PR introduce a breaking change or require work elsewhere?**
No


* **Other context/information**:
N/A