### PR TITLE
Correct sha256 checksum for Pidgin

### DIFF
--- a/automatic/pidgin/tools/chocolateyInstall.ps1
+++ b/automatic/pidgin/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@
 $packageArgs = @{
     packageName   = $env:ChocolateyPackageName
     url           = 'https://netcologne.dl.sourceforge.net/project/pidgin/Pidgin/2.14.9/pidgin-2.14.9-offline.exe'
-    checksum 		  = 'a7b48fb28fa025b7526ecbc46d10be9a2390e089fb3f8cbc8bf4b821b180aeeb'
+    checksum 		  = '160fc847175c55171cede5d030b5f730befa639365d61d3032417d331252989f'
     checksumType 	= 'SHA256'
     fileType      = 'EXE'
     silentArgs    = '/S'


### PR DESCRIPTION
* **Does this PR meet the requirements:**
- [x] The commit messages are appropriate
- [x] This has been tested as far as practicable to ensure intended functionality is fine


* **What kind of change does this PR introduce?** (Bug/issue fix, new package, documentation update, etc...)
This fixes (again)  the incorrect SHA256 checksum on the Pidgin installer


* **What does this PR accomplish?** (Links to issues are acceptable)
See above


* **Does this PR introduce a breaking change or require work elsewhere?**
No


* **Other context/information**:
Checksum was obtained from https://sourceforge.net/projects/pidgin/files/Pidgin/2.14.9/pidgin-2.14.9-offline.exe.sha256sum/download