### PR TITLE
Correct Pidgin installer checksum

### DIFF
--- a/automatic/pidgin/tools/chocolateyInstall.ps1
+++ b/automatic/pidgin/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@
 $packageArgs = @{
     packageName   = $env:ChocolateyPackageName
     url           = 'https://netcologne.dl.sourceforge.net/project/pidgin/Pidgin/2.14.9/pidgin-2.14.9-offline.exe'
-    checksum 		  = 'a7b48fb28fa025b7526ecbc46d10be9a2390e089fb3f8cbc8bf4b821b180aeeb'
+    checksum 		  = '3bb3186222a491aae4da1c87544da30dab405b0f7f974bba6fd60963ec6c73c6'
     checksumType 	= 'SHA256'
     fileType      = 'EXE'
     silentArgs    = '/S'


### PR DESCRIPTION
* **Does this PR meet the requirements:**
- [x] The commit messages are appropriate
- [x] This has been tested as far as practicable to ensure intended functionality is fine


* **What kind of change does this PR introduce?** (Bug/issue fix, new package, documentation update, etc...)
Much like #27, this fixes the incorrect Pidgin SHA-256 checksum from the latest release. Checksum was pulled from https://sourceforge.net/projects/pidgin/files/Pidgin/2.14.10/pidgin-2.14.10.exe.sha256sum/download and manually confirmed.


* **What does this PR accomplish?** (Links to issues are acceptable)
Allows Pidgin to be installed


* **Does this PR introduce a breaking change or require work elsewhere?**
No


* **Other context/information**:
