### PR TITLE
sqlite-studio.portable update

### DIFF
--- a/automatic/sqlite-studio.portable/tools/chocolateyInstall.ps1
+++ b/automatic/sqlite-studio.portable/tools/chocolateyInstall.ps1
@@ -6,8 +6,11 @@ $toolsDir   = Join-Path -Path (Get-ToolsLocation) -ChildPath 'sqlite-studio.port
 $packageArgs = @{
     packageName    = $env:ChocolateyPackageName
     url            = 'https://github.com//pawelsalawa/sqlitestudio/releases/download/3.3.3/sqlitestudio-3.3.3.zip'
+    url64          = ''
     checksum       = 'da888b08b075c71999002b903757d7842746925d8092c00efbd11fc594192494'
     checksumType   = 'SHA256'
+    checksum64     = ''
+    checksumType64 = 'SHA256'
 
     unzipLocation  = $toolsDir
 }

--- a/automatic/sqlite-studio.portable/update.ps1
+++ b/automatic/sqlite-studio.portable/update.ps1
@@ -10,6 +10,9 @@ function global:au_SearchReplace {
             '(^\s*url\s*=\s*)(''.*'')'              = "`$1'$($Latest.URL32)'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum32)'"
             "(?i)(^\s*checksumType\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType32)'"
+            '(^\s*url64\s*=\s*)(''.*'')'            = "`$1'$($Latest.URL64)'"
+            "(?i)(^\s*checksum64\s*=\s*)('.*')"       = "`$1'$($Latest.Checksum64)'"
+            "(?i)(^\s*checksumType64\s*=\s*)('.*')"   = "`$1'$($Latest.ChecksumType64)'"
         }
     }
 }
@@ -17,6 +20,8 @@ function global:au_SearchReplace {
 function global:au_BeforeUpdate {
     $Latest.Checksum32 = Get-RemoteChecksum $Latest.Url32
     $Latest.ChecksumType32 = 'SHA256'
+    $Latest.Checksum64 = Get-RemoteChecksum $Latest.Url64
+    $Latest.ChecksumType64 = 'SHA256'
 }
 
 function global:au_AfterUpdate {
@@ -32,7 +37,8 @@ function global:au_GetLatest {
     $ver = $matches.version
 
     return @{
-        URL32        = "https://github.com/pawelsalawa/sqlitestudio/releases/download/$ver/sqlitestudio-$ver.zip"
+        URL32        = "https://github.com/pawelsalawa/sqlitestudio/releases/download/$ver/sqlitestudio_i386-$ver.zip"
+        URL64        = "https://github.com/pawelsalawa/sqlitestudio/releases/download/$ver/sqlitestudio_x64-$ver.zip"
         Version      = $ver
     }
 }


### PR DESCRIPTION
Latest release (3.4.0) was failing due to an updated filename including the addition of an i386 binary and x64 binary seaparately.

This PR adds the two separate binaries by updating the install script alongside the updater. I have ensured this package meets the required minimum standards and should pass the chocolatey package validation and verification of the install/uninstall process.