### PR TITLE
Add headers to HTTP call

### DIFF
--- a/automatic/msiafterburner/tools/chocolateyInstall.ps1
+++ b/automatic/msiafterburner/tools/chocolateyInstall.ps1
@@ -1,5 +1,12 @@
 ﻿$packageName = 'msiafterburner'
-$url = 'http://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip?__token__=' + $(Invoke-RestMethod https://www.msi.com/api/v1/get_token?date=$(Get-Date -format "yyyyMMddHH"))
+$Date = Get-Date -format "yyyyMMddHHmmss"
+# Define headers to prevent ERROR: Access Denied
+$Headers = @{
+    "accept"          ='text/html,application/xhtml+xml,application/xml'
+    "accept-language" ='en'
+}
+$Token = Invoke-RestMethod -Uri "https://www.msi.com/api/v1/get_token?date=$Date" -Headers $Headers
+$url = "https://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip?__token__=$Token"
 $checksum = '407cf0f38b4b6b3dc030e70329d35be5eabfef45829240cc6df0442768189cec'
 $checksumType = 'SHA256'
 $unpackDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)


### PR DESCRIPTION
Add accept headers to HTTP call to retrieve token to prevent access denied error.

* **Does this PR meet the requirements:**
- [x] The commit messages are appropriate
- [x] This has been tested as far as practicable to ensure intended functionality is fine


* **What kind of change does this PR introduce?** (Bug/issue fix, new package, documentation update, etc...)
Add accept headers to HTTP call to retrieve token to prevent access denied error.


* **What does this PR accomplish?** (Links to issues are acceptable)
This PR aims at resolving the access denied issue thrown by the HTTP call to retrieve the token to build the download URL.


* **Does this PR introduce a breaking change or require work elsewhere?**
No.


* **Other context/information**:
Error thrown by chocolatey
```
ERROR:
Access Denied

Access Denied

You don't have permission to access "http&#58;&#47;&#47;www&#46;msi&#46;com&#47;api&#47;v1&#47;get&#95;token&#63;" on this server.
```