### PR TITLE
Pidgin: Fix broken URL

### DIFF
--- a/automatic/pidgin/tools/chocolateyInstall.ps1
+++ b/automatic/pidgin/tools/chocolateyInstall.ps1
@@ -2,7 +2,7 @@
 
 $packageArgs = @{
     packageName   = $env:ChocolateyPackageName
-    url           = 'https://netcologne.dl.sourceforge.net/project/pidgin/Pidgin/2.14.14/pidgin-2.14.14-offline.exe'
+    url           = 'https://sourceforge.net/projects/pidgin/files/Pidgin/2.14.14/pidgin-2.14.14-offline.exe/download'
     checksum 		  = '7551389982bd9a85991df7436ca1776e68bdc057374c03e8018173e95162bc84'
     checksumType 	= 'sha256'
     fileType      = 'EXE'

--- a/automatic/pidgin/update.ps1
+++ b/automatic/pidgin/update.ps1
@@ -25,7 +25,7 @@ function global:au_GetLatest {
     $version = $matches.version
 
     return @{
-        URL32        = "https://netcologne.dl.sourceforge.net/project/pidgin/Pidgin/$version/pidgin-$version-offline.exe"
+        URL32      = "https://sourceforge.net/projects/pidgin/files/Pidgin/$version/pidgin-$version-offline.exe/download"
         Version    = $version
     }
 }


### PR DESCRIPTION
This PR fixes the broken download URL for Pidgin package.

The old URL does not exist anymore which leads to a download error also affected depending packages